### PR TITLE
Implement TCP checks

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -53,6 +53,8 @@ jobs:
           SOURCES: |
             GitHub->https://github.com
             Facebook->https://facebook.com
+            Never SSL->http://oldsplendidfresheclipse.neverssl.com/online/
+            TCPTest->tcp://tcpbin.com:4242
           GITHUB_TOKEN: ${{ github.token }}
           JOB_NAME: ${{ github.workflow }}
           ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}

--- a/log/src/checks/http.ts
+++ b/log/src/checks/http.ts
@@ -1,7 +1,7 @@
-import { ActionLogger } from "./github/types";
+import { ActionLogger } from "../github/types";
 import axios, { AxiosError } from "axios";
 
-export class StatusChecker {
+export class HTTPChecker {
     constructor(private readonly siteName: string, private readonly healthEndpoint: string,
         private readonly logger: ActionLogger) {
         logger.info(`Created Status Checker for ${siteName}`);

--- a/log/src/checks/tcp.ts
+++ b/log/src/checks/tcp.ts
@@ -28,6 +28,8 @@ function attemptConnection(host: string, port: number, logger: ActionLogger, ret
         // If it's anything other then a connection refused, retry
         if (!err.message.includes("ECONNREFUSED")) {
             handleRetry();
+        } else {
+            resolve(false); // Resolve the promise on ECONNREFUSED
         }
       });
 

--- a/log/src/checks/tcp.ts
+++ b/log/src/checks/tcp.ts
@@ -1,0 +1,93 @@
+import * as net from 'net';
+import { ActionLogger } from "../github/types";
+
+function attemptConnection(host: string, port: number, logger: ActionLogger, retryCount: number = 5): Promise<boolean> {
+  return new Promise((resolve) => {
+    let attempts = 0;
+
+    function attemptConnection() {
+      const socket = new net.Socket();
+
+      // Set a timeout for the connection attempt
+      socket.setTimeout(1000);
+
+      // Attempt to connect to the specified host and port
+      socket.on('connect', () => {
+        // If connected, destroy the socket and resolve true
+        socket.removeAllListeners();  // Clean up listeners
+        socket.destroy();
+        resolve(true);
+
+      });
+
+      // Handle errors that occur during the connection attempt
+      socket.on('error', (err) => {
+        logger.error(`Connection error: ${err.message}`);
+        socket.removeAllListeners();
+        socket.destroy();
+        // If it's anything other then a connection refused, retry
+        if (!err.message.includes("ECONNREFUSED")) {
+            handleRetry();
+        }
+      });
+
+      // Handle timeout scenario
+      socket.on('timeout', () => {
+        logger.error('Connection timeout');
+        socket.destroy();
+        resolve(false);
+      });
+
+      function handleRetry() {
+        if (attempts < retryCount) {
+          attempts += 1;
+          logger.info(`Retrying... (${attempts}/${retryCount})`);
+          setTimeout(attemptConnection, 500); // Retry after .5 seconds
+        } else {
+          resolve(false); // Failed after retrying
+        }
+      }
+
+      socket.connect(port, host);
+    }
+
+    attemptConnection();
+
+  });
+}
+
+export class TCPChecker {
+    constructor(private readonly siteName: string, private readonly healthEndpoint: string,
+        private readonly logger: ActionLogger) {
+        this.logger.info(`Created Status Checker for ${siteName}`);
+    }
+
+    async verifyEndpoint(): Promise<boolean> {
+        const [host, portString] = this.healthEndpoint.replace('tcp://', '').split(':');
+        if (!host) {
+            this.logger.error('Invalid host: Host cannot be empty');
+            return false;
+        }
+
+        // Convert the port part to a number
+        const port = parseInt(portString, 10);
+        if (Number.isNaN(port) || port < 1 || port > 65535) {
+            this.logger.error(`Invalid port number: ${portString}`);
+            return false;
+        }
+
+        try {
+            const isConnected = await attemptConnection(host, port, this.logger);
+        if (isConnected) {
+            this.logger.info('Connection successful');
+            return true;
+        } else {
+            this.logger.info('Connection failed');
+            return false;
+        }
+      } catch (error) {
+            this.logger.error('Error during connection attempt: ' + error);
+            return false;
+      }
+    }
+}

--- a/log/src/test/index.test.ts
+++ b/log/src/test/index.test.ts
@@ -1,6 +1,6 @@
 import { ArtifactManager } from "../github/artifact";
 import { GitHubClient } from "../github/types";
-import { StatusChecker } from "../status";
+import { HTTPChecker } from "../checks/http";
 import { ReportFile } from "../types";
 
 const sites: Array<[string, string]> = [
@@ -11,7 +11,7 @@ const sites: Array<[string, string]> = [
 
 for (const [site, url] of sites) {
   test(`Test obtaining metrics from ${site}`, async () => {
-    const statusChecker = new StatusChecker(site, url, console);
+    const statusChecker = new HTTPChecker(site, url, console);
     await expect(statusChecker.verifyEndpoint()).resolves.toBe(true);
   })
 }
@@ -20,7 +20,7 @@ test("Write to doc", async () => {
   const siteResult: ReportFile["site"] = [];
 
   for (const [site, url] of sites) {
-    const statusChecker = new StatusChecker(site, url, console);
+    const statusChecker = new HTTPChecker(site, url, console);
     siteResult.push({ name: site, status: [{ timestamp: new Date().getTime(), result: (await statusChecker.verifyEndpoint()) }] });
   }
   const am = new ArtifactManager(null as unknown as GitHubClient, console, "test");


### PR DESCRIPTION
There was so many messy commits on the previous PR, I figured I should clean the whole thing up. 

This PR implements the ability to have multiple different types of checks. 

It also implements a first alternative check the TCP check. This will make a TCP connection, close and report back if it was successful. Should an unexpected error happen (other then Connection Refused) it will re-try up to 5 times. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added TCP connection health check functionality
  - Enhanced URL validation for health checks
  - Expanded health check sources with additional endpoints

- **Bug Fixes**
  - Improved error handling for endpoint verification
  - Added support for TCP protocol in health checks

- **Refactor**
  - Renamed `StatusChecker` to `HTTPChecker`
  - Updated import paths and code structure
  - Implemented more robust URL validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->