### PR TITLE
Add action runs when labels are added or removed

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -7,7 +7,7 @@ on:
   schedule:
     - cron: '0 */2 * * *'
   issues:
-    types: [opened, closed]
+    types: [opened, closed, labeled, unlabeled]
 
 env:
   ARTIFACT_NAME: reports


### PR DESCRIPTION
This PR adds two settings to the Github Actions On issues statement. It adds the `labeled` and `unlabeled` issue types. 

By adding these two, actions are run when a label is added or removed to an issue. This allows faster response time when adding or removing the the `incident` label. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to trigger on additional issue event types (labeled and unlabeled)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->